### PR TITLE
Enable finalizer elision for HashMap backing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! [here]: https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h
 //! [CppCon talk]: https://www.youtube.com/watch?v=ncHmEUmJZf4
 
+#![feature(gc)]
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
@@ -44,7 +45,9 @@
 extern crate std;
 
 #[cfg_attr(test, macro_use)]
+#[allow(unused_extern_crates)]
 extern crate alloc;
+
 
 #[cfg(feature = "nightly")]
 #[cfg(doctest)]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,6 +1,7 @@
 use crate::alloc::alloc::{handle_alloc_error, Layout};
 use crate::scopeguard::{guard, ScopeGuard};
 use crate::TryReserveError;
+use core::gc::DropMethodFinalizerElidable;
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem;
@@ -3657,6 +3658,8 @@ impl<T, A: Allocator + Default> Default for RawTable<T, A> {
         Self::new_in(Default::default())
     }
 }
+
+unsafe impl<T, A: Allocator > DropMethodFinalizerElidable for RawTable<T, A> {}
 
 #[cfg(feature = "nightly")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for RawTable<T, A> {


### PR DESCRIPTION
I'm not sure what the best way to raise this is. Our version of hashbrown is v0.14.5, which is a bit behind master at this point. We can't merge my changes into master unless we rebased Alloy with rustc so they'll have to be a separate branch for now. I'm raising a draft PR so that you can still have eyes on this, but if you have another suggestion I'm open to it? 